### PR TITLE
Integrate auth flow with Conviven backend

### DIFF
--- a/app/(app)/index.tsx
+++ b/app/(app)/index.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "../../context/AuthContext";
 export default function HomeScreen() {
   const { user, logout } = useAuth();
 
-  const name = user?.name ?? "User";
+  const name = user?.name ?? [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "User";
   const email = user?.email ?? "No email";
 
   return (
@@ -30,8 +30,7 @@ export default function HomeScreen() {
           <View className="bg-gray-50 p-4 rounded-lg">
             <Text className="font-semibold mb-1">Authentication Ready</Text>
             <Text className="text-gray-600">
-              The app includes a complete authentication flow with login, registration, and session
-              management.
+              The app connects to the Conviven backend for login, registration and profile retrieval.
             </Text>
           </View>
 

--- a/app/(app)/profile.tsx
+++ b/app/(app)/profile.tsx
@@ -4,15 +4,27 @@ import { View, Text, Image, ScrollView } from "react-native";
 import Button from "../../components/Button";
 import { useAuth } from "../../context/AuthContext";
 
+const formatLabel = (label?: string | null) => {
+  if (!label) {
+    return "Not available";
+  }
+
+  return label;
+};
+
 export default function ProfileScreen() {
   const { user } = useAuth();
 
-  const name = user?.name ?? "Anonymous";
+  const name = user?.name ?? [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "Anonymous";
   const email = user?.email ?? "No email provided";
   const avatar = user?.avatar ?? null;
   const bio = user?.bio ?? "No bio provided";
-  const location = user?.location ?? "Not specified";
+  const location = user?.location ?? user?.departmentName ?? "Not specified";
   const phone = user?.phone ?? "Not provided";
+  const birthDate = user?.birthDate ?? "Not provided";
+  const gender = user?.gender ?? "Not provided";
+  const department = user?.departmentName ?? user?.departmentId ?? "Not provided";
+  const neighborhood = user?.neighborhoodName ?? user?.neighborhoodId ?? "Not provided";
 
   return (
     <ScrollView className="flex-1 bg-white">
@@ -22,9 +34,7 @@ export default function ProfileScreen() {
             <Image source={{ uri: avatar }} className="w-28 h-28 rounded-full" />
           ) : (
             <View className="w-28 h-28 rounded-full bg-indigo-100 items-center justify-center">
-              <Text className="text-3xl font-semibold text-indigo-700">
-                {name?.charAt(0) || "U"}
-              </Text>
+              <Text className="text-3xl font-semibold text-indigo-700">{name?.charAt(0) || "U"}</Text>
             </View>
           )}
           <Text className="text-2xl font-bold mt-4">{name}</Text>
@@ -45,7 +55,23 @@ export default function ProfileScreen() {
               </View>
               <View>
                 <Text className="text-gray-500 text-sm">User ID</Text>
-                <Text className="font-medium">{user?.id ?? "Not available"}</Text>
+                <Text className="font-medium">{formatLabel(user?.id)}</Text>
+              </View>
+              <View>
+                <Text className="text-gray-500 text-sm">Birth Date</Text>
+                <Text className="font-medium">{birthDate}</Text>
+              </View>
+              <View>
+                <Text className="text-gray-500 text-sm">Gender</Text>
+                <Text className="font-medium">{gender}</Text>
+              </View>
+              <View>
+                <Text className="text-gray-500 text-sm">Department</Text>
+                <Text className="font-medium">{department}</Text>
+              </View>
+              <View>
+                <Text className="text-gray-500 text-sm">Neighborhood</Text>
+                <Text className="font-medium">{neighborhood}</Text>
               </View>
               <View>
                 <Text className="text-gray-500 text-sm">Bio</Text>

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -9,23 +9,39 @@ interface RegisterFormProps {
   isLoading?: boolean;
 }
 
+const GENDERS = ["MALE", "FEMALE", "OTHER"];
+
 export default function RegisterForm({ onSubmit, isLoading = false }: RegisterFormProps) {
-  const [name, setName] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [birthDate, setBirthDate] = useState("");
+  const [gender, setGender] = useState("MALE");
+  const [departmentId, setDepartmentId] = useState("");
+  const [neighborhoodId, setNeighborhoodId] = useState("");
   const [errors, setErrors] = useState<{
-    name?: string;
+    firstName?: string;
+    lastName?: string;
     email?: string;
     password?: string;
     confirmPassword?: string;
+    birthDate?: string;
+    gender?: string;
+    departmentId?: string;
+    neighborhoodId?: string;
   }>({});
 
   const validate = (): boolean => {
     const newErrors: typeof errors = {};
 
-    if (!name) {
-      newErrors.name = "Name is required";
+    if (!firstName) {
+      newErrors.firstName = "First name is required";
+    }
+
+    if (!lastName) {
+      newErrors.lastName = "Last name is required";
     }
 
     if (!email) {
@@ -44,6 +60,26 @@ export default function RegisterForm({ onSubmit, isLoading = false }: RegisterFo
       newErrors.confirmPassword = "Passwords do not match";
     }
 
+    if (!birthDate) {
+      newErrors.birthDate = "Birth date is required";
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) {
+      newErrors.birthDate = "Use YYYY-MM-DD format";
+    }
+
+    if (!gender) {
+      newErrors.gender = "Gender is required";
+    } else if (!GENDERS.includes(gender.toUpperCase())) {
+      newErrors.gender = `Gender must be one of: ${GENDERS.join(", ")}`;
+    }
+
+    if (!departmentId) {
+      newErrors.departmentId = "Department ID is required";
+    }
+
+    if (!neighborhoodId) {
+      newErrors.neighborhoodId = "Neighborhood ID is required";
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -51,7 +87,16 @@ export default function RegisterForm({ onSubmit, isLoading = false }: RegisterFo
   const handleSubmit = async () => {
     if (validate()) {
       try {
-        await onSubmit({ name, email, password });
+        await onSubmit({
+          email,
+          password,
+          firstName,
+          lastName,
+          birthDate,
+          gender: gender.toUpperCase(),
+          departmentId,
+          neighborhoodId,
+        });
       } catch (error) {
         throw error;
       }
@@ -61,16 +106,33 @@ export default function RegisterForm({ onSubmit, isLoading = false }: RegisterFo
   return (
     <View className="w-full p-4">
       <View className="mb-4">
-        <Text className="mb-2 text-gray-700">Name</Text>
+        <Text className="mb-2 text-gray-700">First Name</Text>
         <TextInput
-          className={`p-4 border rounded-md ${errors.name ? "border-red-500" : "border-gray-300"}`}
-          value={name}
-          onChangeText={setName}
-          placeholder="Your name"
+          className={`p-4 border rounded-md ${errors.firstName ? "border-red-500" : "border-gray-300"}`}
+          value={firstName}
+          onChangeText={text => {
+            setFirstName(text);
+            setErrors(prev => ({ ...prev, firstName: undefined }));
+          }}
+          placeholder="Your first name"
           autoCapitalize="words"
-          onFocus={() => setErrors({ ...errors, name: undefined })}
         />
-        {errors.name && <Text className="mt-1 text-red-500">{errors.name}</Text>}
+        {errors.firstName && <Text className="mt-1 text-red-500">{errors.firstName}</Text>}
+      </View>
+
+      <View className="mb-4">
+        <Text className="mb-2 text-gray-700">Last Name</Text>
+        <TextInput
+          className={`p-4 border rounded-md ${errors.lastName ? "border-red-500" : "border-gray-300"}`}
+          value={lastName}
+          onChangeText={text => {
+            setLastName(text);
+            setErrors(prev => ({ ...prev, lastName: undefined }));
+          }}
+          placeholder="Your last name"
+          autoCapitalize="words"
+        />
+        {errors.lastName && <Text className="mt-1 text-red-500">{errors.lastName}</Text>}
       </View>
 
       <View className="mb-4">
@@ -78,11 +140,13 @@ export default function RegisterForm({ onSubmit, isLoading = false }: RegisterFo
         <TextInput
           className={`p-4 border rounded-md ${errors.email ? "border-red-500" : "border-gray-300"}`}
           value={email}
-          onChangeText={setEmail}
+          onChangeText={text => {
+            setEmail(text);
+            setErrors(prev => ({ ...prev, email: undefined }));
+          }}
           placeholder="your@email.com"
           autoCapitalize="none"
           keyboardType="email-address"
-          onFocus={() => setErrors({ ...errors, email: undefined })}
         />
         {errors.email && <Text className="mt-1 text-red-500">{errors.email}</Text>}
       </View>
@@ -92,27 +156,99 @@ export default function RegisterForm({ onSubmit, isLoading = false }: RegisterFo
         <TextInput
           className={`p-4 border rounded-md ${errors.password ? "border-red-500" : "border-gray-300"}`}
           value={password}
-          onChangeText={setPassword}
+          onChangeText={text => {
+            setPassword(text);
+            setErrors(prev => ({ ...prev, password: undefined }));
+          }}
           placeholder="Your password"
           secureTextEntry
-          onFocus={() => setErrors({ ...errors, password: undefined })}
         />
         {errors.password && <Text className="mt-1 text-red-500">{errors.password}</Text>}
       </View>
 
-      <View className="mb-6">
+      <View className="mb-4">
         <Text className="mb-2 text-gray-700">Confirm Password</Text>
         <TextInput
           className={`p-4 border rounded-md ${errors.confirmPassword ? "border-red-500" : "border-gray-300"}`}
           value={confirmPassword}
-          onChangeText={setConfirmPassword}
+          onChangeText={text => {
+            setConfirmPassword(text);
+            setErrors(prev => ({ ...prev, confirmPassword: undefined }));
+          }}
           placeholder="Confirm your password"
           secureTextEntry
-          onFocus={() => setErrors({ ...errors, confirmPassword: undefined })}
         />
         {errors.confirmPassword && (
           <Text className="mt-1 text-red-500">{errors.confirmPassword}</Text>
         )}
+      </View>
+
+      <View className="mb-4">
+        <Text className="mb-2 text-gray-700">Birth Date</Text>
+        <TextInput
+          className={`p-4 border rounded-md ${errors.birthDate ? "border-red-500" : "border-gray-300"}`}
+          value={birthDate}
+          onChangeText={text => {
+            setBirthDate(text);
+            setErrors(prev => ({ ...prev, birthDate: undefined }));
+          }}
+          placeholder="2001-06-28"
+          autoCapitalize="none"
+        />
+        <Text className="mt-1 text-xs text-gray-500">Formato requerido: AAAA-MM-DD</Text>
+        {errors.birthDate && <Text className="mt-1 text-red-500">{errors.birthDate}</Text>}
+      </View>
+
+      <View className="mb-4">
+        <Text className="mb-2 text-gray-700">Gender</Text>
+        <TextInput
+          className={`p-4 border rounded-md ${errors.gender ? "border-red-500" : "border-gray-300"}`}
+          value={gender}
+          onChangeText={text => {
+            setGender(text);
+            setErrors(prev => ({ ...prev, gender: undefined }));
+          }}
+          placeholder={`One of: ${GENDERS.join(", ")}`}
+          autoCapitalize="characters"
+        />
+        <Text className="mt-1 text-xs text-gray-500">Valores permitidos: {GENDERS.join(", ")}</Text>
+        {errors.gender && <Text className="mt-1 text-red-500">{errors.gender}</Text>}
+      </View>
+
+      <View className="mb-4">
+        <Text className="mb-2 text-gray-700">Department ID</Text>
+        <TextInput
+          className={`p-4 border rounded-md ${errors.departmentId ? "border-red-500" : "border-gray-300"}`}
+          value={departmentId}
+          onChangeText={text => {
+            setDepartmentId(text);
+            setErrors(prev => ({ ...prev, departmentId: undefined }));
+          }}
+          placeholder="Department identifier"
+          autoCapitalize="none"
+        />
+        <Text className="mt-1 text-xs text-gray-500">
+          Ejemplo: a2f0e079-c922-44f2-8712-e2710fad74e3
+        </Text>
+        {errors.departmentId && <Text className="mt-1 text-red-500">{errors.departmentId}</Text>}
+      </View>
+
+      <View className="mb-6">
+        <Text className="mb-2 text-gray-700">Neighborhood ID</Text>
+        <TextInput
+          className={`p-4 border rounded-md ${errors.neighborhoodId ? "border-red-500" : "border-gray-300"}`}
+          value={neighborhoodId}
+          onChangeText={text => {
+            setNeighborhoodId(text);
+            setErrors(prev => ({ ...prev, neighborhoodId: undefined }));
+          }}
+          placeholder="Neighborhood identifier"
+          autoCapitalize="none"
+        />
+        <Text className="mt-1 text-xs text-gray-500">
+          Ejemplo: 23a75a72-2deb-4fd0-b8bb-98c48b03fa14
+        </Text>
+        {errors.neighborhoodId && <Text className="mt-1 text-red-500">{errors.neighborhoodId}</Text>}
       </View>
 
       <Button

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -43,7 +43,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           const user = await AuthService.getCurrentUser();
           setState({
             user,
-            isAuthenticated: true,
+            isAuthenticated: !!user,
             isLoading: false,
             error: null,
           });
@@ -69,9 +69,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, []);
 
   const login = async (credentials: LoginCredentials) => {
-    try {
-      setState({ ...state, isLoading: true, error: null });
+    setState(prev => ({ ...prev, isLoading: true, error: null }));
 
+    try {
       const user = await AuthService.login(credentials);
 
       setState({
@@ -81,19 +81,22 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         error: null,
       });
     } catch (error) {
-      setState({
-        ...state,
+      const message = error instanceof Error ? error.message : "Login failed";
+
+      setState(prev => ({
+        ...prev,
         isLoading: false,
-        error: error instanceof Error ? error.message : "Login failed",
-      });
+        error: message,
+      }));
+
       throw error;
     }
   };
 
   const register = async (credentials: RegisterCredentials) => {
-    try {
-      setState({ ...state, isLoading: true, error: null });
+    setState(prev => ({ ...prev, isLoading: true, error: null }));
 
+    try {
       const user = await AuthService.register(credentials);
 
       setState({
@@ -103,19 +106,22 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         error: null,
       });
     } catch (error) {
-      setState({
-        ...state,
+      const message = error instanceof Error ? error.message : "Registration failed";
+
+      setState(prev => ({
+        ...prev,
         isLoading: false,
-        error: error instanceof Error ? error.message : "Registration failed",
-      });
+        error: message,
+      }));
+
       throw error;
     }
   };
 
   const logout = async () => {
-    try {
-      setState({ ...state, isLoading: true, error: null });
+    setState(prev => ({ ...prev, isLoading: true, error: null }));
 
+    try {
       await AuthService.logout();
 
       setState({
@@ -125,17 +131,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         error: null,
       });
     } catch (error) {
-      setState({
-        ...state,
+      const message = error instanceof Error ? error.message : "Logout failed";
+
+      setState(prev => ({
+        ...prev,
         isLoading: false,
-        error: error instanceof Error ? error.message : "Logout failed",
-      });
+        error: message,
+      }));
+
       Alert.alert("Logout Error", "Failed to log out. Please try again.");
     }
   };
 
   const clearError = () => {
-    setState({ ...state, error: null });
+    setState(prev => ({ ...prev, error: null }));
   };
 
   const contextValue: AuthContextType = {

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -1,120 +1,266 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-import { User, LoginCredentials } from "../types/user";
+import { User, LoginCredentials, RegisterCredentials } from "../types/user";
 
+const API_BASE_URL = "https://conviven-backend.onrender.com/api";
 const AUTH_TOKEN_KEY = "auth_token";
 const USER_DATA_KEY = "user_data";
 
-const MOCK_USER: User = {
-  id: "1",
-  email: "user@example.com",
-  name: "Test User",
-  avatar: "https://via.placeholder.com/150",
-};
+function buildUrl(path: string): string {
+  return `${API_BASE_URL}${path}`;
+}
+
+async function parseResponse(response: Response): Promise<any> {
+  const contentType = response.headers.get("content-type");
+  let payload: any = null;
+
+  if (contentType?.includes("application/json")) {
+    payload = await response.json();
+  } else {
+    const text = await response.text();
+    payload = text || null;
+  }
+
+  if (!response.ok) {
+    const message =
+      typeof payload === "string"
+        ? payload
+        : payload?.message || payload?.error || `Request failed with status ${response.status}`;
+
+    throw new Error(message);
+  }
+
+  return payload;
+}
+
+function extractToken(data: any): string | null {
+  if (!data) {
+    return null;
+  }
+
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (typeof data !== "object") {
+    return null;
+  }
+
+  const possibleToken =
+    data.token ||
+    data.accessToken ||
+    data.access_token ||
+    data.jwt ||
+    data.idToken ||
+    data.authToken;
+
+  if (typeof possibleToken === "string") {
+    return possibleToken;
+  }
+
+  const tokensContainer =
+    data.tokens ||
+    data.tokenData ||
+    data.credentials ||
+    data.session ||
+    data.data?.tokens;
+
+  if (tokensContainer) {
+    const nestedToken = extractToken(tokensContainer);
+    if (nestedToken) {
+      return nestedToken;
+    }
+
+    if (typeof tokensContainer === "object") {
+      const accessToken =
+        tokensContainer.accessToken ||
+        tokensContainer.access_token ||
+        tokensContainer.access?.token ||
+        tokensContainer.access?.accessToken;
+
+      if (typeof accessToken === "string") {
+        return accessToken;
+      }
+    }
+  }
+
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      const token = extractToken(item);
+      if (token) {
+        return token;
+      }
+    }
+  }
+
+  if (data.data) {
+    return extractToken(data.data);
+  }
+
+  return null;
+}
+
+function mapUser(data: any): User {
+  if (!data || typeof data !== "object") {
+    throw new Error("Invalid user payload received from server");
+  }
+
+  const firstName = data.firstName || data.firstname || data.name?.split(" ")?.[0] || undefined;
+  const lastName = data.lastName || data.lastname || undefined;
+  const department = data.department || {};
+  const neighborhood = data.neighborhood || {};
+
+  const composedName = `${firstName ?? ""} ${lastName ?? ""}`.trim();
+  const name =
+    (typeof data.name === "string" && data.name.trim()) ||
+    (composedName.length > 0 ? composedName : undefined) ||
+    data.email ||
+    undefined;
+
+  return {
+    id: data.id || data._id || "",
+    email: data.email || "",
+    name: name || "Usuario",
+    firstName,
+    lastName,
+    avatar: data.avatar || data.avatarUrl || undefined,
+    bio: data.bio || undefined,
+    location: data.location || data.address?.name || undefined,
+    phone: data.phone || undefined,
+    birthDate: data.birthDate || data.birthdate || undefined,
+    gender: data.gender || undefined,
+    departmentId: department.id || data.departmentId || undefined,
+    departmentName: department.name || undefined,
+    neighborhoodId: neighborhood.id || data.neighborhoodId || undefined,
+    neighborhoodName: neighborhood.name || undefined,
+  };
+}
+
+async function persistUser(user: User): Promise<void> {
+  await AsyncStorage.setItem(USER_DATA_KEY, JSON.stringify(user));
+}
 
 export default class AuthService {
-  /**
-   * Login with email and password
-   */
   static async login(credentials: LoginCredentials): Promise<User> {
-    try {
-      await new Promise(resolve => setTimeout(resolve, 1000));
+    const response = await fetch(buildUrl("/auth/login"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(credentials),
+    });
 
-      if (!credentials.email || !credentials.password) {
-        throw new Error("Email and password are required");
-      }
+    const data = await parseResponse(response);
 
-      if (credentials.email === "test@example.com" && credentials.password === "password") {
-        const token = `mock-jwt-token-${Date.now()}`;
-        await AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
+    const token = extractToken(data);
 
-        await AsyncStorage.setItem(USER_DATA_KEY, JSON.stringify(MOCK_USER));
-
-        return MOCK_USER;
-      }
-
-      throw new Error("Invalid email or password");
-    } catch (error) {
-      throw error;
+    if (!token) {
+      throw new Error("No authentication token returned by the server");
     }
+
+    await AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
+
+    const userPayload = data.user || data.data?.user;
+    let user: User;
+
+    if (userPayload) {
+      user = mapUser(userPayload);
+    } else {
+      user = await this.fetchCurrentUserWithToken(token);
+    }
+
+    await persistUser(user);
+
+    return user;
   }
 
-  /**
-   * Register a new user
-   */
-  static async register(userData: LoginCredentials & { name: string }): Promise<User> {
-    try {
-      await new Promise(resolve => setTimeout(resolve, 1000));
+  static async register(credentials: RegisterCredentials): Promise<User> {
+    const response = await fetch(buildUrl("/users/register"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: credentials.email,
+        password: credentials.password,
+        firstName: credentials.firstName,
+        lastName: credentials.lastName,
+        birthDate: credentials.birthDate,
+        gender: credentials.gender,
+        departmentId: credentials.departmentId,
+        neighborhoodId: credentials.neighborhoodId,
+      }),
+    });
 
-      if (!userData.email || !userData.password || !userData.name) {
-        throw new Error("All fields are required");
-      }
+    const data = await parseResponse(response);
 
-      const newUser = {
-        ...MOCK_USER,
-        email: userData.email,
-        name: userData.name,
-      };
+    let token = extractToken(data);
 
-      const token = `mock-jwt-token-${Date.now()}`;
-      await AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
+    if (!token) {
+      // If the register endpoint doesn't return a token, attempt to log in with the same credentials
+      const user = await this.login({
+        email: credentials.email,
+        password: credentials.password,
+      });
 
-      await AsyncStorage.setItem(USER_DATA_KEY, JSON.stringify(newUser));
-
-      return newUser;
-    } catch (error) {
-      throw error;
+      return user;
     }
+
+    await AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
+
+    const userPayload = data.user || data.data?.user;
+    let user: User;
+
+    if (userPayload) {
+      user = mapUser(userPayload);
+    } else {
+      user = await this.fetchCurrentUserWithToken(token);
+    }
+
+    await persistUser(user);
+
+    return user;
   }
 
-  /**
-   * Logout the current user
-   */
   static async logout(): Promise<void> {
-    try {
-      await new Promise(resolve => setTimeout(resolve, 500));
-
-      await AsyncStorage.multiRemove([AUTH_TOKEN_KEY, USER_DATA_KEY]);
-    } catch (error) {
-      console.error("Logout error:", error);
-      throw error;
-    }
+    await AsyncStorage.multiRemove([AUTH_TOKEN_KEY, USER_DATA_KEY]);
   }
 
-  /**
-   * Get the current user profile
-   */
   static async getCurrentUser(): Promise<User | null> {
-    try {
-      const token = await AsyncStorage.getItem(AUTH_TOKEN_KEY);
+    const token = await AsyncStorage.getItem(AUTH_TOKEN_KEY);
 
-      if (!token) {
-        return null;
-      }
-
-      const userData = await AsyncStorage.getItem(USER_DATA_KEY);
-
-      if (!userData) {
-        return null;
-      }
-
-      return JSON.parse(userData) as User;
-    } catch (error) {
-      console.error("Get current user error:", error);
+    if (!token) {
       return null;
     }
+
+    try {
+      const user = await this.fetchCurrentUserWithToken(token);
+      await persistUser(user);
+      return user;
+    } catch (error) {
+      console.error("Get current user error:", error);
+      const cachedUser = await AsyncStorage.getItem(USER_DATA_KEY);
+      return cachedUser ? (JSON.parse(cachedUser) as User) : null;
+    }
   }
 
-  /**
-   * Check if the user is authenticated
-   */
   static async isAuthenticated(): Promise<boolean> {
-    try {
-      const token = await AsyncStorage.getItem(AUTH_TOKEN_KEY);
-      return !!token;
-    } catch (error) {
-      console.error("Auth check error:", error);
-      return false;
-    }
+    const token = await AsyncStorage.getItem(AUTH_TOKEN_KEY);
+    return !!token;
+  }
+
+  private static async fetchCurrentUserWithToken(token: string): Promise<User> {
+    const response = await fetch(buildUrl("/users/me"), {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await parseResponse(response);
+
+    const userPayload = data.user || data.data || data;
+    const user = mapUser(userPayload);
+    return user;
   }
 }

--- a/types/user.ts
+++ b/types/user.ts
@@ -2,10 +2,18 @@ export interface User {
   id: string;
   email: string;
   name: string;
+  firstName?: string;
+  lastName?: string;
   avatar?: string;
   bio?: string;
   location?: string;
   phone?: string;
+  birthDate?: string;
+  gender?: string;
+  departmentId?: string;
+  departmentName?: string;
+  neighborhoodId?: string;
+  neighborhoodName?: string;
 }
 
 export interface AuthState {
@@ -21,5 +29,10 @@ export interface LoginCredentials {
 }
 
 export interface RegisterCredentials extends LoginCredentials {
-  name: string;
+  firstName: string;
+  lastName: string;
+  birthDate: string;
+  gender: string;
+  departmentId: string;
+  neighborhoodId: string;
 }


### PR DESCRIPTION
## Summary
- connect the authentication service to the Conviven API for login, registration, profile retrieval, and session storage
- extend user types and registration form fields to match the backend contract and surface new profile information
- refresh documentation and authenticated screens to reflect backend-driven data instead of mocks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d9952e986c8322ac14bd6a8afed4ea