### PR TITLE
Add cascading location selectors to register form

### DIFF
--- a/services/authService.ts
+++ b/services/authService.ts
@@ -197,6 +197,10 @@ export default class AuthService {
       neighborhoodId: credentials.neighborhoodId,
     };
 
+    if (credentials.cityId) {
+      registerPayload.cityId = credentials.cityId;
+    }
+
     if (credentials.role) {
       registerPayload.role = credentials.role;
     }

--- a/types/user.ts
+++ b/types/user.ts
@@ -103,6 +103,7 @@ export interface RegisterCredentials extends LoginCredentials {
   birthDate: string;
   gender: Gender | string;
   departmentId: string;
+  cityId?: string;
   neighborhoodId: string;
   role?: UserRole;
 }
@@ -115,6 +116,7 @@ export interface PublicRegisterPayload {
   birthDate: string;
   gender: Gender;
   departmentId: string;
+  cityId?: string;
   neighborhoodId: string;
   role?: UserRole;
   status?: UserStatus;
@@ -128,6 +130,7 @@ export interface AdminRegisterPayload {
   birthDate: string;
   gender: Gender;
   departmentId: string;
+  cityId?: string;
   neighborhoodId: string;
 }
 


### PR DESCRIPTION
## Summary
- replace manual department and neighborhood inputs with cascading pickers for department, city, and neighborhood
- load location options via LocationService as each selection is made and enforce city selection during validation
- include optional cityId field in registration payloads so the backend receives the selected city

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a5a39a3083329f5711d135884baa